### PR TITLE
Removed abstract static function (not supported anymore)

### DIFF
--- a/lib/ApeAbstractConnection.php
+++ b/lib/ApeAbstractConnection.php
@@ -116,15 +116,4 @@ abstract class ApeAbstractConnection {
 	 */	    
     abstract protected function doSendRequest(ApeRequest $request);
 
-	/**
-	 * Checks wether connection service is available.
-	 * Must be implemented by concrete classes.
-	 *
-	 * @abstract
-	 * @static
-	 * @access public
-	 * @return boolean connection service is available?
-	 * @since  Available since release 0.1.0.
-	 */	    
-    abstract public static function available();
 } 

--- a/lib/ApeResponse.php
+++ b/lib/ApeResponse.php
@@ -101,7 +101,8 @@ class ApeResponse {
 	protected static function decodeResponse($rawResponse){
 		if(trim((string)$rawResponse) != ''){
 			try{
-				$response = array_shift(json_decode($rawResponse));
+				$raw      = json_decode($rawResponse);
+				$response = array_shift($raw);
 			}			
 			catch(Exception $e){
 				throw new ApeException('could not decode raw response'); 


### PR DESCRIPTION
ApeAbstractConnection.php: Abstract Static Functions are not supported
since PHP 5.2
ApeResponse.php: removed "Only variables should be passed by reference "
error message
